### PR TITLE
Uses 'map(str, message)' to convert each element in the 'message' lis…

### DIFF
--- a/start.py
+++ b/start.py
@@ -108,7 +108,7 @@ class bcolors:
 
 def exit(*message):
     if message:
-        logger.error(bcolors.FAIL + " ".join(message) + bcolors.RESET)
+        logger.error(bcolors.FAIL + " ".join(map(str, message)) + bcolors.RESET)
     shutdown()
     _exit(1)
 


### PR DESCRIPTION
…t to a string to fix error 'TypeError: sequence item 0: expected str instance, int found'

Before:
user@host:MHDDoS# python3 start.py tools
host:MHTools:~# help
Tools:CHECK, CFIP, DSTAT, INFO, TSSRV, PING, DNS
Commands: HELP, CLEAR, BACK, EXIT
host:MHTools:~# exit
Traceback (most recent call last):
  File "/home/user/MHDDoS/start.py", line 1556, in <module>
    ToolsConsole.runConsole()
  File "/home/user/MHDDoS/start.py", line 1303, in runConsole
    exit(-1)
  File "/home/user/MHDDoS/start.py", line 111, in exit
    logger.error(bcolors.FAIL + " ".join(message) + bcolors.RESET)
TypeError: sequence item 0: expected str instance, int found

After:
user@host:MHDDoS# python3 start.py tools
host:MHTools:~# exit
[10:48:53 - ERROR] -1
