### PR TITLE
Potential fix for code scanning alert no. 3: Use of insecure SSL/TLS version

### DIFF
--- a/start.py
+++ b/start.py
@@ -44,6 +44,7 @@ logger.setLevel("INFO")
 ctx: SSLContext = create_default_context(cafile=where())
 ctx.check_hostname = False
 ctx.verify_mode = CERT_NONE
+ctx.minimum_version = ctx.TLSVersion.TLSv1_2
 
 __version__: str = "2.4 SNAPSHOT"
 __dir__: Path = Path(__file__).parent


### PR DESCRIPTION
Potential fix for [https://github.com/MatrixTM/MHDDoS/security/code-scanning/3](https://github.com/MatrixTM/MHDDoS/security/code-scanning/3)

The best way to fix the problem is to explicitly restrict the allowed TLS versions on the `SSLContext` to TLS 1.2 or higher. This is done by setting `ctx.minimum_version` to `ssl.TLSVersion.TLSv1_2` immediately after the context is created. You should update the region after `ctx` is created in start.py (around line 44) to add this statement.  
Also, to ensure consistency and avoid ambiguity, check that the protocol is set for the single global context used for HTTPS connections. You do not need to modify the way the socket wrapping on line 875 works, only ensure that the context itself is securely configured.

Required change: Add `ctx.minimum_version = ssl.TLSVersion.TLSv1_2` after line 46 (where context options are set).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
